### PR TITLE
Fix apk error when updating py-pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine:latest
 
 # Install python and pip
-RUN apk add --update python py-pip bash 
+RUN apk add --update python py2-pip bash 
 ADD ./webapp/requirements.txt /tmp/requirements.txt
 
 # Install dependencies


### PR DESCRIPTION
### Problem:
Attempting to build the image results in the following error:

```
ERROR: unsatisfiable constraints:
  py-pip (virtual):
    provided by: py2-pip
    required by: world[py-pip]
The command '/bin/sh -c apk add --update python py-pip bash' returned a non-zero code: 1
```

### Cause:
The py-pip package has been renamed to py2-pip.

### Fix:
I updated the py-pip package name.