### PR TITLE
Update Dockerfile & requirements for python3 stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@
 FROM alpine:latest
 
 # Install python and pip
-RUN apk add --no-cache --update python py-pip bash
+RUN apk add --no-cache --update python3 py3-pip bash
 ADD ./webapp/requirements.txt /tmp/requirements.txt
 
 # Install dependencies
-RUN pip install --no-cache-dir -q -r /tmp/requirements.txt
+RUN pip3 install --no-cache-dir -q -r /tmp/requirements.txt
 
 # Add our code
 ADD ./webapp /opt/webapp/

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -2,5 +2,3 @@ gunicorn
 Flask
 Jinja2
 Werkzeug
-distribute
-wsgiref


### PR DESCRIPTION
Prior to this commit, this example was using Python 2.x.  However, as
of 2018-04-25, Heroku's current non-Docker documentation pushes users
towards Python 3.x:

https://devcenter.heroku.com/articles/getting-started-with-python#introduction

Quote:

"The tutorial assumes that you have: . . . Python version 3.6"

This change harmonizes this example with those instructions.

Notes on the dropped dependencies in webapp/requirements.txt:
+ the legacy distribute package is no longer needed
+ wsgiref is in Python 3's standard library