### PR TITLE
Fix OSError('libc not found')

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine:latest
 
 # Install python and pip
-RUN apk add --no-cache --update python3 py3-pip bash
+RUN apk add --no-cache --update python3 py3-pip bash libc-dev
 ADD ./webapp/requirements.txt /tmp/requirements.txt
 
 # Install dependencies


### PR DESCRIPTION
Gunicorn 20.0.0 requires the package libc-dev
https://stackoverflow.com/questions/58786695/how-to-address-oserror-libc-not-found-raised-on-gunicorn-exec-of-flask-app-in