### PR TITLE
prevent RUN pip3 install build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-#Grab the latest alpine image
-FROM alpine:latest
+#Grab alpine image
+FROM python:3.13.0a2-alpine
 
 # Install python and pip
 RUN apk add --no-cache --update python3 py3-pip bash


### PR DESCRIPTION
prevent this build error by using working alpine image without update application code


#8 [4/7] RUN pip3 install --no-cache-dir -q -r /tmp/requirements.txt #8 2.007 error: externally-managed-environment
#8 2.007 
#8 2.007 �� This environment is externally managed #8 2.007 ������> 
#8 2.007     The system-wide python installation should be maintained using the system
#8 2.007     package manager (apk) only.
#8 2.007     
#8 2.007     If the package in question is not packaged already (and hence installable via
#8 2.007     "apk add py3-somepackage"), please consider installing it inside a virtual
#8 2.007     environment, e.g.:
#8 2.007     
#8 2.007     python3 -m venv /path/to/venv
#8 2.007     . /path/to/venv/bin/activate
#8 2.007     pip install mypackage
#8 2.007     
#8 2.007     To exit the virtual environment, run:
#8 2.007     
#8 2.007     deactivate
#8 2.007     
#8 2.007     The virtual environment is not deleted, and can be re-entered by re-sourcing
#8 2.007     the activate file.
#8 2.007     
#8 2.007     To automatically manage virtual environments, consider using pipx (from the
#8 2.007     pipx package).
#8 2.007 
#8 2.007 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
#8 2.007 hint: See PEP 668 for the detailed specification.
#8 ERROR: process "/bin/sh -c pip3 install --no-cache-dir -q -r /tmp/requirements.txt" did not complete successfully: exit code: 1